### PR TITLE
server: Redirect root path to /status

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -57,6 +57,9 @@ func runServer() error {
 	//	debug.GET("/threadcreate", gin.WrapH(pprof.Handler("threadcreate")))
 	//}
 
+	router.GET("/", func(c *gin.Context) {
+		c.Redirect(301, "/status")
+	})
 	router.GET("/img/:image", icon)
 	for _, i := range animationDuration {
 		d := strings.TrimSuffix(i.String(), "0m0s")


### PR DESCRIPTION
Added a route to redirect requests from '/' to '/status' with a 301 status code. This improves user navigation by directing root requests to the status page.