### PR TITLE
server: Add restart options to service configuration

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -46,6 +46,7 @@ func init() {
 		Dependencies: []string{"Wants=network-online.target", "After=network.target"},
 		Environment:  map[string]string{"GIN_MODE": "release"},
 		ExcludeFiles: []string{"scripts/weather.conf"},
+		Others:       []string{"Restart=always", "RestartSec=60"},
 	}
 	svc.RegisterCommand("report", "report", func(_ ...string) error {
 		if err := initWeather(); err != nil {


### PR DESCRIPTION
Added 'Restart=always' and 'RestartSec=60' to the service configuration to improve reliability by ensuring the service restarts automatically after failure.