### PR TITLE
Wrap chrome init with panic recovery; bump module

### DIFF
--- a/api/zoomearth/map.go
+++ b/api/zoomearth/map.go
@@ -277,13 +277,13 @@ $('.timeline').style.margin='0 auto'`, nil),
 }
 
 func Map(path string, dt time.Time, coords coordinates.Coordinates, opt *MapOptions) (t time.Time, img image.Image, err error) {
-	c := chrome.Headless()
-	defer c.Close()
 	defer func() {
 		if e := recover(); e != nil {
 			err = fmt.Errorf("failed to get map: %v", e)
 		}
 	}()
+	c := chrome.Headless()
+	defer c.Close()
 	return MapWithContext(c, path, dt, coords, opt)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 require (
 	github.com/chromedp/cdproto v0.0.0-20260321001828-e3e3800016bc
 	github.com/chromedp/chromedp v0.15.1
-	github.com/sunshineplan/chrome v1.1.26
+	github.com/sunshineplan/chrome v1.1.27
 	github.com/sunshineplan/utils v0.1.84
 )
 

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kUL
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhAVbbWWBzr41ElhJx5tXPWkIHA2HWPRuw=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
-github.com/sunshineplan/chrome v1.1.26 h1:8riWUQ4GWhxWfDrPUiBKSXKkuxhJsIN5CH/l8CERmyI=
-github.com/sunshineplan/chrome v1.1.26/go.mod h1:is1GBjZZDKCmLt1WvNkAptnJM7h/MDp2a/I/PYsCRBQ=
+github.com/sunshineplan/chrome v1.1.27 h1:unM3oo9JYWjMl5cFAMa4M8jb+2nWM+loxugZjOl+oE8=
+github.com/sunshineplan/chrome v1.1.27/go.mod h1:drht4MC99a6eRJpaIPUwzCIhSvLjnm2CY/Lz10PpShg=
 github.com/sunshineplan/utils v0.1.84 h1:RMZK73sz8THyQueGn5qxu0+Bh+4QvSf+Z+OEikVZKyY=
 github.com/sunshineplan/utils v0.1.84/go.mod h1:K5M8sNh+F47+aHfABZIiFJHVhC2DhiNhGZ9SgBQPPdE=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/server/go.mod
+++ b/server/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/pschlump/ansi v1.0.0 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect
-	github.com/sunshineplan/chrome v1.1.26 // indirect
+	github.com/sunshineplan/chrome v1.1.27 // indirect
 	github.com/sunshineplan/cipher v1.0.7 // indirect
 	github.com/sunshineplan/progressbar v1.0.1 // indirect
 	github.com/tidwall/gjson v1.18.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -136,8 +136,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/sunshineplan/ai v1.0.23 h1:cwhapNcx2aS5gXeYBfhzEiEf8sVQLdFYUeZ/c9PO3HI=
 github.com/sunshineplan/ai v1.0.23/go.mod h1:B6gcZBawJ3IdhShlV4eqol0DVyMpKBoAlHUrxb53LEc=
-github.com/sunshineplan/chrome v1.1.26 h1:8riWUQ4GWhxWfDrPUiBKSXKkuxhJsIN5CH/l8CERmyI=
-github.com/sunshineplan/chrome v1.1.26/go.mod h1:is1GBjZZDKCmLt1WvNkAptnJM7h/MDp2a/I/PYsCRBQ=
+github.com/sunshineplan/chrome v1.1.27 h1:unM3oo9JYWjMl5cFAMa4M8jb+2nWM+loxugZjOl+oE8=
+github.com/sunshineplan/chrome v1.1.27/go.mod h1:drht4MC99a6eRJpaIPUwzCIhSvLjnm2CY/Lz10PpShg=
 github.com/sunshineplan/cipher v1.0.7 h1:uC2BwJWO8wDHZu/yUsrMVlhjL400rIco542GCywOw04=
 github.com/sunshineplan/cipher v1.0.7/go.mod h1:7AXZEo7seaA5/Zd2id+1pi4yNHQ2eAmIN5YNjmrGelQ=
 github.com/sunshineplan/database/mongodb v1.0.15 h1:EG7SuJhoXN8pzTzBYLBQdnKioHSVzRdNKVCWl5nNBno=


### PR DESCRIPTION
Move chrome.Headless() initialization to occur after a defer recover block so any panic during headless browser creation or map generation is caught and converted to an error. Also update github.com/sunshineplan/chrome to v1.1.27 in go.mod to pick up upstream changes.